### PR TITLE
add lib size and n hashes to permanova

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -263,6 +263,14 @@ rule name_filtered_sigs:
     sourmash sig rename -o {output} -k 31 {input} {wildcards.library}_filt
     '''
 
+rule describe_filtered_sigs:
+    input: expand("outputs/filt_sigs_named/{library}_filt_named.sig", library = LIBRARIES)
+    output: "outputs/filt_sigs_named/sig_describe_filt_named_sig.csv"
+    conda: 'sourmash.yml'
+    shell:'''
+    sourmash signature describe --csv {output} {input}
+    '''
+
 rule convert_greater_than_1_signatures_to_csv:
     input: "outputs/filt_sigs_named/{library}_filt_named.sig"
     output: "outputs/filt_sigs_named_csv/{library}_filt_named.csv"
@@ -795,7 +803,8 @@ rule compare_signatures_jaccard:
 rule permanova_jaccard:
     input: 
         comp = "outputs/comp/all_filt_comp_jaccard.csv",
-        info = "inputs/working_metadata.tsv"
+        info = "inputs/working_metadata.tsv",
+        sig_info = "outputs/filt_sigs_named/sig_describe_filt_named_sig.csv"
     output: 
         perm = "outputs/comp/all_filt_permanova_jaccard.csv"
     conda: "vegan.yml"
@@ -804,7 +813,8 @@ rule permanova_jaccard:
 rule permanova_cosine:
     input: 
         comp = "outputs/comp/all_filt_comp_cosine.csv",
-        info = "inputs/working_metadata.tsv"
+        info = "inputs/working_metadata.tsv",
+        sig_info = "outputs/filt_sigs_named/sig_describe_filt_named_sig.csv"
     output: 
         perm = "outputs/comp/all_filt_permanova_cosine.csv"
     conda: "vegan.yml"

--- a/scripts/run_permanova.R
+++ b/scripts/run_permanova.R
@@ -15,6 +15,12 @@ info <- read_tsv(snakemake@input[['info']]) %>%
   summarise(read_count = sum(read_count)) %>%
   as.data.frame()
 
+sigs <- read_csv(snakemake@input[['sig_info']]) %>%
+  mutate(name = gsub("_filt", "", name)) %>%
+  select(name, n_hashes)
+
+info <- left_join(info, sigs, by = c("library_name" = "name"))
+
 # dist and permanova ------------------------------------------------------
 
 dist <- dist(comp)                                       # compute distances
@@ -23,7 +29,7 @@ info$diagnosis <- as.factor(info$diagnosis)              # set factors for model
 info$study_accession <- as.factor(info$study_accession)
 info$subject <- as.factor(info$subject)
 
-perm <- adonis(dist ~ diagnosis + study_accession, 
+perm <- adonis(dist ~ diagnosis + study_accession + read_count + n_hashes, 
                data = info, 
                permutations = 10000)
 


### PR DESCRIPTION
Adds library size and number of hashes to the permanova. Adds a rule to describe the filtered signatures that build the compare matrix, and adds R code to combine the number of hashes reported by sig describe to the sample info dataframe.